### PR TITLE
Fix internship person id null handling and minor UI errors

### DIFF
--- a/src/main/java/seedu/address/ui/InternshipCard.java
+++ b/src/main/java/seedu/address/ui/InternshipCard.java
@@ -48,7 +48,7 @@ public class InternshipCard extends UiPart<Region> {
         role.setText(internship.getInternshipRole().roleName);
         status.getChildren().add(new Label(internship.getInternshipStatus().toString()));
         if (internship.getContactPersonId() == null) {
-            contactPersonId.setText("-1");
+            contactPersonId.setText("No contact person.");
         } else {
             contactPersonId.setText(internship.getContactPersonId().id.toString());
         }

--- a/src/main/java/seedu/address/ui/InternshipCard.java
+++ b/src/main/java/seedu/address/ui/InternshipCard.java
@@ -47,7 +47,11 @@ public class InternshipCard extends UiPart<Region> {
         companyName.setText(internship.getCompanyName().fullName);
         role.setText(internship.getInternshipRole().roleName);
         status.getChildren().add(new Label(internship.getInternshipStatus().toString()));
-        contactPersonId.setText(internship.getContactPersonId().id.toString());
+        if (internship.getContactPersonId() == null) {
+            contactPersonId.setText("-1");
+        } else {
+            contactPersonId.setText(internship.getContactPersonId().id.toString());
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -35,8 +35,6 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label phone;
     @FXML
-    private Label address;
-    @FXML
     private Label email;
     @FXML
     private FlowPane tags;

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -29,7 +29,6 @@
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>
   </GridPane>


### PR DESCRIPTION
Currently, internship objects created without person id will set person id as null
Then, when the GUI tries to create the internship card, it incurs a NullPointerException.
This pull request mitigates it by fixing the text to -1 instead.