### PR TITLE
Implement person linking for add internship command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddInternshipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInternshipCommand.java
@@ -6,8 +6,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LINK_INDEX;
 
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.internship.CompanyName;
@@ -30,14 +33,14 @@ public class AddInternshipCommand extends Command {
             + PREFIX_COMPANY_NAME + "COMPANY_NAME "
             + PREFIX_INTERNSHIP_ROLE + "INTERNSHIP_ROLE "
             + PREFIX_INTERNSHIP_STATUS + "INTERNSHIP_STATUS "
-            + "[" + PREFIX_PERSON_ID + "PERSON_ID] "
-            + "[" + PREFIX_INTERVIEW_DATE + "INTERVIEW_DATE]\n"
+            + "[" + PREFIX_INTERVIEW_DATE + "INTERVIEW_DATE] "
+            + "[" + PREFIX_LINK_INDEX + "LINK_INDEX]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_COMPANY_NAME + "Google "
             + PREFIX_INTERNSHIP_ROLE + "Frontend Engineer "
             + PREFIX_INTERNSHIP_STATUS + "PENDING "
-            + PREFIX_PERSON_ID + "1 "
-            + PREFIX_INTERVIEW_DATE + "2022-10-21 12:00";
+            + PREFIX_INTERVIEW_DATE + "2022-10-21 12:00 "
+            + PREFIX_LINK_INDEX + "1 ";
 
     public static final String MESSAGE_SUCCESS = "New internship added: %1$s";
     public static final String MESSAGE_DUPLICATE_INTERNSHIP = "This internship already exists in the address book";
@@ -47,6 +50,7 @@ public class AddInternshipCommand extends Command {
     private final InternshipStatus internshipStatus;
     private final PersonId contactPersonId;
     private final InterviewDate interviewDate;
+    private final Index linkIndex;
 
     /**
      * Creates an AddCommand to add the specified {@code Internship}
@@ -58,6 +62,7 @@ public class AddInternshipCommand extends Command {
         this.internshipStatus = internship.getInternshipStatus();
         this.contactPersonId = internship.getContactPersonId();
         this.interviewDate = internship.getInterviewDate();
+        this.linkIndex = null;
     }
 
     /**
@@ -69,42 +74,47 @@ public class AddInternshipCommand extends Command {
             CompanyName companyName,
             InternshipRole internshipRole,
             InternshipStatus internshipStatus,
-            PersonId contactPersonId,
-            InterviewDate interviewDate) {
+            InterviewDate interviewDate,
+            Index linkIndex) {
         requireAllNonNull(companyName, internshipRole, internshipStatus);
         this.companyName = companyName;
         this.internshipRole = internshipRole;
         this.internshipStatus = internshipStatus;
-        this.contactPersonId = contactPersonId;
+
+        // contactPersonId is to be gotten using the linkIndex in this case
+        this.contactPersonId = null;
+
         this.interviewDate = interviewDate;
+        this.linkIndex = linkIndex;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        Person contactPerson = model.findPersonById(contactPersonId);
+        // By default, use the contactPersonId field in the command
+        PersonId idToLink = contactPersonId;
 
-        Internship toAdd;
-        if (contactPerson == null) {
-            toAdd = new Internship(
-                    new InternshipId(model.getNextInternshipId()),
-                    companyName,
-                    internshipRole,
-                    internshipStatus,
-                    null,
-                    interviewDate
-            );
-        } else {
-            toAdd = new Internship(
-                    new InternshipId(model.getNextInternshipId()),
-                    companyName,
-                    internshipRole,
-                    internshipStatus,
-                    contactPersonId,
-                    interviewDate
-            );
+        List<Person> lastShownList = model.getFilteredPersonList();
+        // If a linkIndex is supplied to the command,
+        // attempt to find a contactPerson via the provided index in the filtered person list
+        if (linkIndex != null && linkIndex.getZeroBased() < lastShownList.size()) {
+            Person contactPerson = lastShownList.get(linkIndex.getZeroBased());
+
+            // The person to link to must not already be linked to an internship
+            if (contactPerson.getInternshipId() == null) {
+                idToLink = contactPerson.getPersonId();
+            }
         }
+
+        Internship toAdd = new Internship(
+                new InternshipId(model.getNextInternshipId()),
+                companyName,
+                internshipRole,
+                internshipStatus,
+                idToLink,
+                interviewDate
+        );
 
         if (model.hasInternship(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_INTERNSHIP);

--- a/src/main/java/seedu/address/logic/parser/AddInternshipCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddInternshipCommandParser.java
@@ -5,17 +5,17 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LINK_INDEX;
 
 import java.util.stream.Stream;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddInternshipCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.InternshipRole;
 import seedu.address.model.internship.InternshipStatus;
 import seedu.address.model.internship.InterviewDate;
-import seedu.address.model.person.PersonId;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -35,8 +35,8 @@ public class AddInternshipCommandParser implements Parser<AddInternshipCommand> 
                         PREFIX_COMPANY_NAME,
                         PREFIX_INTERNSHIP_ROLE,
                         PREFIX_INTERNSHIP_STATUS,
-                        PREFIX_PERSON_ID,
-                        PREFIX_INTERVIEW_DATE);
+                        PREFIX_INTERVIEW_DATE,
+                        PREFIX_LINK_INDEX);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_COMPANY_NAME, PREFIX_INTERNSHIP_ROLE, PREFIX_INTERNSHIP_STATUS)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -49,11 +49,20 @@ public class AddInternshipCommandParser implements Parser<AddInternshipCommand> 
                 ParserUtil.parseInternshipRole(argMultimap.getValue(PREFIX_INTERNSHIP_ROLE).get());
         InternshipStatus internshipStatus =
                 ParserUtil.parseInternshipStatus(argMultimap.getValue(PREFIX_INTERNSHIP_STATUS).get());
-        PersonId contactPersonId = ParserUtil.parsePersonId(argMultimap.getValue(PREFIX_PERSON_ID).orElse(null));
-        InterviewDate interviewDate =
-                ParserUtil.parseInterviewDate(argMultimap.getValue(PREFIX_INTERVIEW_DATE).orElse(null));
 
-        return new AddInternshipCommand(companyName, internshipRole, internshipStatus, contactPersonId, interviewDate);
+        String interviewDateStr = argMultimap.getValue(PREFIX_INTERVIEW_DATE).orElse(null);
+        InterviewDate interviewDate = null;
+        if (interviewDateStr != null) {
+            interviewDate = ParserUtil.parseInterviewDate(interviewDateStr);
+        }
+
+        String linkIndexStr = argMultimap.getValue(PREFIX_LINK_INDEX).orElse(null);
+        Index linkIndex = null;
+        if (linkIndexStr != null) {
+            linkIndex = ParserUtil.parseIndex(linkIndexStr);
+        }
+
+        return new AddInternshipCommand(companyName, internshipRole, internshipStatus, interviewDate, linkIndex);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,9 +15,11 @@ public class CliSyntax {
 
     /* Prefix definitions (Internship) */
     public static final Prefix PREFIX_INTERNSHIP_ID = new Prefix("iid/");
-    public static final Prefix PREFIX_COMPANY_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_COMPANY_NAME = new Prefix("c/");
     public static final Prefix PREFIX_INTERNSHIP_ROLE = new Prefix("r/");
     public static final Prefix PREFIX_INTERNSHIP_STATUS = new Prefix("s/");
     public static final Prefix PREFIX_INTERVIEW_DATE = new Prefix("d/");
 
+    /* Prefix definitions (Common) */
+    public static final Prefix PREFIX_LINK_INDEX = new Prefix("l/");
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -41,6 +41,7 @@ public class ParserUtil {
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
 
+    // TODO: Remove this method.
     /**
      * Parses a {@code String personId} into a {@code PersonId}.
      * Leading and trailing whitespaces will be trimmed.
@@ -131,6 +132,7 @@ public class ParserUtil {
         return tagSet;
     }
 
+    // TODO: Remove this method.
     /**
      * Parses a {@code String internshipId} into a {@code InternshipId}.
      * Leading and trailing whitespaces will be trimmed.

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -163,11 +163,17 @@ public class AddressBook implements ReadOnlyAddressBook {
 
         persons.add(p);
 
-        InternshipId internshipId = p.getInternshipId();
-        if (internshipId != null) {
-            // TODO: Find the associated Internship via Id,
-            //  then set the contactPersonId of the Internship to p.getPersonId().
-            //  Requires new Set method.
+        Internship i = findInternshipById(p.getInternshipId());
+        if (i != null) {
+            Internship linkedI = new Internship(
+                    i.getInternshipId(),
+                    i.getCompanyName(),
+                    i.getInternshipRole(),
+                    i.getInternshipStatus(),
+                    p.getPersonId(),
+                    i.getInterviewDate()
+            );
+            setInternship(i, linkedI);
         }
     }
 
@@ -181,11 +187,17 @@ public class AddressBook implements ReadOnlyAddressBook {
 
         internships.add(i);
 
-        PersonId contactPersonId = i.getContactPersonId();
-        if (contactPersonId != null) {
-            // TODO: Find the associated Person via Id,
-            //  then set internshipId of the Person to i.getInternshipId().
-            //  Requires new Set method.
+        Person p = findPersonById(i.getContactPersonId());
+        if (p != null) {
+            Person linkedP = new Person(
+                    p.getPersonId(),
+                    p.getName(),
+                    p.getPhone(),
+                    p.getEmail(),
+                    i.getInternshipId(),
+                    p.getTags()
+            );
+            setPerson(p, linkedP);
         }
     }
 
@@ -212,6 +224,21 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+
+        updateNextPersonId();
+
+        Internship i = findInternshipById(key.getInternshipId());
+        if (i != null) {
+            Internship linkedI = new Internship(
+                    i.getInternshipId(),
+                    i.getCompanyName(),
+                    i.getInternshipRole(),
+                    i.getInternshipStatus(),
+                    null,
+                    i.getInterviewDate()
+            );
+            setInternship(i, linkedI);
+        }
     }
 
     /**
@@ -220,6 +247,21 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removeInternship(Internship key) {
         internships.remove(key);
+
+        updateNextInternshipId();
+
+        Person p = findPersonById(key.getContactPersonId());
+        if (p != null) {
+            Person linkedP = new Person(
+                    p.getPersonId(),
+                    p.getName(),
+                    p.getPhone(),
+                    p.getEmail(),
+                    null,
+                    p.getTags()
+            );
+            setPerson(p, linkedP);
+        }
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -30,7 +30,7 @@ public class SampleDataUtil {
                     new Name("Alex Yeoh"),
                     new Phone("87438807"),
                     new Email("alexyeoh@example.com"),
-                    null,
+                    new InternshipId(0),
                     getTagSet("friends")),
             new Person(
                     new PersonId(1),
@@ -65,7 +65,7 @@ public class SampleDataUtil {
                     new Name("Roy Balakrishnan"),
                     new Phone("92624417"),
                     new Email("royb@example.com"),
-                    new InternshipId(0),
+                    new InternshipId(1),
                     getTagSet("colleagues"))
         };
     }
@@ -77,7 +77,7 @@ public class SampleDataUtil {
                     new CompanyName("company ABC123"),
                     new InternshipRole("frontend engineer"),
                     new InternshipStatus(InternshipStatus.State.ACCEPTED),
-                    new PersonId(5),
+                    new PersonId(0),
                     null),
             new Internship(
                     new InternshipId(1),

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -20,7 +20,7 @@ public class HelpWindow extends UiPart<Stage> {
     public static final String USERGUIDE_URL = "https://ay2223s1-cs2103t-f11-1.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide for full details: " + USERGUIDE_URL
             + "\nA summary of the command is provided below for convenience.";
-    public static final Image helpSummary = new Image("/images/help_summary.png");
+    public static final Image HELP_SUMMARY = new Image("/images/help_summary.png");
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
 
@@ -41,7 +41,7 @@ public class HelpWindow extends UiPart<Stage> {
     public HelpWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
-        helpImage.setImage(helpSummary);
+        helpImage.setImage(HELP_SUMMARY);
     }
 
     /**


### PR DESCRIPTION
### Update AddInternshipCommand to support linking

- Modify `AddInternshipCommandParser` to now parse an `Index`, which will be used to find the person to link the newly created `Internship` to
    - Modify `CLISyntax` prefixes to match UG and new command format for add internship
    - Modify `AddInternshipCommand` class to support linking via use of `Index` #79 
- Update `AddressBook` methods for add and remove to support 2-way linking #98
    - Modify `addPerson` such that if the `Person` to add contains a link to some `Internship`, then a link is also established from that `Internship` to this `Person, and vice versa for `addInternship`
    - Modify `removePerson` such that if the `Person` to remove contains a link to some `Internship`, then the link from that `Internship` to this `Person` is also removed, and vice versa for `removeInternship`
- Fix bugs related to adding internship #81

### Fix misc. issues and Checkstyle issues to pass CI 

- Update `SampleDataUtil` to generate correct data
- Rename field in `HelpWindow` to follow style
- Add TODOs for removing soon-to-be unused methods in `ParserUtil`