### PR TITLE
Add internship ID to person card display

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -115,7 +115,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList(), logic.getAddressBook());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -7,6 +7,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import seedu.address.model.internship.InternshipId;
 import seedu.address.model.person.Person;
 
 /**
@@ -15,6 +16,7 @@ import seedu.address.model.person.Person;
 public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
+    private static final String NO_INTERNSHIP = "No internship linked.";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -58,6 +60,18 @@ public class PersonCard extends UiPart<Region> {
             internship.setText("No internships linked.");
         } else {
             internship.setText("Internship: " + person.getInternshipId().toString());
+        }
+    }
+
+    public InternshipId getInternshipId() {
+        return person.getInternshipId();
+    }
+
+    public void setInternship(String internshipName) {
+        if (internshipName == null) {
+            internship.setText(NO_INTERNSHIP);
+        } else {
+            internship.setText("Internship: " + internshipName);
         }
     }
 

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -38,6 +38,8 @@ public class PersonCard extends UiPart<Region> {
     private Label email;
     @FXML
     private FlowPane tags;
+    @FXML
+    private Label internship;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -52,6 +54,11 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        if (person.getInternshipId() == null) {
+            internship.setText("No internships linked.");
+        } else {
+            internship.setText("Internship: " + person.getInternshipId().toString());
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -57,7 +57,7 @@ public class PersonCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         if (person.getInternshipId() == null) {
-            internship.setText("No internships linked.");
+            internship.setText(NO_INTERNSHIP);
         } else {
             internship.setText("Internship: " + person.getInternshipId().toString());
         }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -8,6 +8,7 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 
 /**
@@ -16,6 +17,7 @@ import seedu.address.model.person.Person;
 public class PersonListPanel extends UiPart<Region> {
     private static final String FXML = "PersonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
+    private ReadOnlyAddressBook addressBook;
 
     @FXML
     private ListView<Person> personListView;
@@ -23,10 +25,11 @@ public class PersonListPanel extends UiPart<Region> {
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList) {
+    public PersonListPanel(ObservableList<Person> personList, ReadOnlyAddressBook addressBook) {
         super(FXML);
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
+        this.addressBook = addressBook;
     }
 
     /**
@@ -41,7 +44,12 @@ public class PersonListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
+                //create person card
+                PersonCard newPersonCard = new PersonCard(person, getIndex() + 1);
+                newPersonCard.setInternship(
+                        addressBook.findInternshipNameById(newPersonCard.getInternshipId()));
+
+                setGraphic(newPersonCard.getRoot());
             }
         }
     }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -30,6 +30,7 @@
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="internship" styleClass="cell_small_label" text="\$internship" />
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
~~This pull request still uses internship ID for now.~~
It now uses company name.

Bugs noted: When name is edited, the link displayed name is not changed (for both person and internship)