### PR TITLE
Fix person and internship internal ID duplicating

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -84,10 +84,11 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void updateNextPersonId() {
         for (Person p : persons) {
-            if (p.getPersonId().id >= personIdCounter) {
-                personIdCounter = p.getPersonId().id + 1;
+            if (p.getPersonId().id > personIdCounter) {
+                personIdCounter = p.getPersonId().id;
             }
         }
+        personIdCounter++;
     }
 
     /**
@@ -95,10 +96,11 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void updateNextInternshipId() {
         for (Internship i : internships) {
-            if (i.getInternshipId().id >= internshipIdCounter) {
-                internshipIdCounter = i.getInternshipId().id + 1;
+            if (i.getInternshipId().id > internshipIdCounter) {
+                internshipIdCounter = i.getInternshipId().id;
             }
         }
+        internshipIdCounter++;
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -114,7 +114,7 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Fills up all the placeholders of this window.
      */
-    void fillInnerParts() {
+    void fillInnerPartsPerson() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList(), logic.getAddressBook());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -42,7 +42,7 @@ public class UiManager implements Ui {
         try {
             mainWindow = new MainWindow(primaryStage, logic);
             mainWindow.show(); //This should be called before creating other UI parts
-            mainWindow.fillInnerParts();
+            mainWindow.fillInnerPartsPerson();
             mainWindow.fillInnerPartsInternship();
         } catch (Throwable e) {
             logger.severe(StringUtil.getDetails(e));


### PR DESCRIPTION
When adding more than 1 person or more than 1 internship, the internal ID gets duplicated as the ID increment is only applied every other addition, as the next ID is updated before the previous one is added.
The increment is shifted to the end so that the increment always happens, instead of only every 2 additions.

This pull request also adjusts a method name in MainWindow.java: ```fillInnerParts()``` -> ```fillInnerPartsPerson()```