### PR TITLE
Fix ID of 1st person/internship added in each run being 0

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -19,6 +19,7 @@ import seedu.address.model.person.UniquePersonList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     // Internal Id counters
+    private boolean hasLoaded = false;
     private int personIdCounter = 0;
     private int internshipIdCounter = 0;
 
@@ -67,6 +68,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @return A unique Id for a newly created Person.
      */
     public int getNextPersonId() {
+        updateNextPersonId();
         return personIdCounter;
     }
 
@@ -76,6 +78,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @return A unique Id for a newly created Internship.
      */
     public int getNextInternshipId() {
+        updateNextInternshipId();
         return internshipIdCounter;
     }
 
@@ -83,10 +86,14 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Updates the next PersonId to be 1 + the largest PersonId in the list.
      */
     public void updateNextPersonId() {
-        for (Person p : persons) {
-            if (p.getPersonId().id > personIdCounter) {
-                personIdCounter = p.getPersonId().id;
+        if (!hasLoaded) {
+            personIdCounter = -1;
+            for (Person p : persons) {
+                if (p.getPersonId().id > personIdCounter) {
+                    personIdCounter = p.getPersonId().id;
+                }
             }
+            hasLoaded = true;
         }
         personIdCounter++;
     }
@@ -95,10 +102,14 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Updates the next InternshipId to be 1 + the largest InternshipId in the list.
      */
     public void updateNextInternshipId() {
-        for (Internship i : internships) {
-            if (i.getInternshipId().id > internshipIdCounter) {
-                internshipIdCounter = i.getInternshipId().id;
+        if (!hasLoaded) {
+            internshipIdCounter = -1;
+            for (Internship i : internships) {
+                if (i.getInternshipId().id > internshipIdCounter) {
+                    internshipIdCounter = i.getInternshipId().id;
+                }
             }
+            hasLoaded = true;
         }
         internshipIdCounter++;
     }
@@ -112,8 +123,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         setPersons(newData.getPersonList());
         setInternships(newData.getInternshipList());
 
-        personIdCounter = 0;
-        internshipIdCounter = 0;
+        hasLoaded = false;
     }
 
     //// person-level operations
@@ -185,8 +195,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      * * Updates the internshipIdCounter to avoid duplicate Ids.
      */
     public void addInternship(Internship i) {
-        updateNextInternshipId();
-
         internships.add(i);
 
         Person p = findPersonById(i.getContactPersonId());
@@ -249,8 +257,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removeInternship(Internship key) {
         internships.remove(key);
-
-        updateNextInternshipId();
 
         Person p = findPersonById(key.getContactPersonId());
         if (p != null) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -19,7 +19,8 @@ import seedu.address.model.person.UniquePersonList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     // Internal Id counters
-    private boolean hasLoaded = false;
+    private boolean hasLoadedInternship = false;
+    private boolean hasLoadedPerson = false;
     private int personIdCounter = 0;
     private int internshipIdCounter = 0;
 
@@ -86,14 +87,14 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Updates the next PersonId to be 1 + the largest PersonId in the list.
      */
     public void updateNextPersonId() {
-        if (!hasLoaded) {
+        if (!hasLoadedPerson) {
             personIdCounter = -1;
             for (Person p : persons) {
                 if (p.getPersonId().id > personIdCounter) {
                     personIdCounter = p.getPersonId().id;
                 }
             }
-            hasLoaded = true;
+            hasLoadedPerson = true;
         }
         personIdCounter++;
     }
@@ -102,14 +103,14 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Updates the next InternshipId to be 1 + the largest InternshipId in the list.
      */
     public void updateNextInternshipId() {
-        if (!hasLoaded) {
+        if (!hasLoadedInternship) {
             internshipIdCounter = -1;
             for (Internship i : internships) {
                 if (i.getInternshipId().id > internshipIdCounter) {
                     internshipIdCounter = i.getInternshipId().id;
                 }
             }
-            hasLoaded = true;
+            hasLoadedInternship = true;
         }
         internshipIdCounter++;
     }
@@ -123,7 +124,8 @@ public class AddressBook implements ReadOnlyAddressBook {
         setPersons(newData.getPersonList());
         setInternships(newData.getInternshipList());
 
-        hasLoaded = false;
+        hasLoadedInternship = false;
+        hasLoadedPerson = false;
     }
 
     //// person-level operations

--- a/src/test/java/seedu/address/logic/commands/AddPersonCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPersonCommandIntegrationTest.java
@@ -27,7 +27,7 @@ public class AddPersonCommandIntegrationTest {
 
     @Test
     public void execute_newPerson_success() {
-        Person validPerson = new PersonBuilder().build();
+        Person validPerson = new PersonBuilder().withPersonId(7).build();
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addPerson(validPerson);


### PR DESCRIPTION
Currently, the ID is set to 0, as the ```updateNext*Id()``` methods are not called for the 1st person/internship being added on the run.
It is changed so that ```getNext*ID()``` will now call ```updateNext*Id()``` so that the ID increases normally.

This pull request also optimises the behaviour of ```updateNext*Id()``` so that it does not need to check through the entire list to determine the next ID, as the invariant that the rate of increase of the highest ID is equal to the rate of increase of the counter is fulfilled.