### PR TITLE
Fix add* to ignore optional fields if they are included but actually blank

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddInternshipCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddInternshipCommandParser.java
@@ -51,11 +51,7 @@ public class AddInternshipCommandParser implements Parser<AddInternshipCommand> 
                 ParserUtil.parseInternshipStatus(argMultimap.getValue(PREFIX_INTERNSHIP_STATUS).get());
 
         String interviewDateStr = argMultimap.getValue(PREFIX_INTERVIEW_DATE).orElse(null);
-        InterviewDate interviewDate = null;
-        if (interviewDateStr != null) {
-            interviewDate = ParserUtil.parseInterviewDate(interviewDateStr);
-        }
-
+        InterviewDate interviewDate = ParserUtil.parseInterviewDate(interviewDateStr);
         String linkIndexStr = argMultimap.getValue(PREFIX_LINK_INDEX).orElse(null);
         Index linkIndex = null;
         if (linkIndexStr != null) {

--- a/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
@@ -46,15 +46,9 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         String emailStr = argMultimap.getValue(PREFIX_EMAIL).orElse(null);
-        Email email = null;
-        if (emailStr != null) {
-            email = ParserUtil.parseEmail(emailStr);
-        }
+        Email email = ParserUtil.parseEmail(emailStr);
         String phoneStr = argMultimap.getValue(PREFIX_PHONE).orElse(null);
-        Phone phone = null;
-        if (phoneStr != null) {
-            phone = ParserUtil.parsePhone(phoneStr);
-        }
+        Phone phone = ParserUtil.parsePhone(phoneStr);
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         String linkIndexStr = argMultimap.getValue(PREFIX_LINK_INDEX).orElse(null);
         Index linkIndex = null;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -98,14 +98,14 @@ public class ParserUtil {
      * @throws ParseException if the given {@code phone} is invalid.
      */
     public static Phone parsePhone(String phone) throws ParseException {
-        if (phone != null) {
-            String trimmedPhone = phone.trim();
-            if (!Phone.isValidPhone(trimmedPhone)) {
-                throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
-            }
-            return new Phone(trimmedPhone);
+        if (phone.isBlank()) {
+            return new Phone(null);
         }
-        return new Phone(null);
+        String trimmedPhone = phone.trim();
+        if (!Phone.isValidPhone(trimmedPhone)) {
+            throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
+        }
+        return new Phone(trimmedPhone);
     }
 
 
@@ -116,7 +116,9 @@ public class ParserUtil {
      * @throws ParseException if the given {@code email} is invalid.
      */
     public static Email parseEmail(String email) throws ParseException {
-        requireNonNull(email);
+        if (email.isBlank()) {
+            return new Email(null);
+        }
         String trimmedEmail = email.trim();
         if (!Email.isValidEmail(trimmedEmail)) {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
@@ -131,7 +133,9 @@ public class ParserUtil {
      * @throws ParseException if the given {@code tag} is invalid.
      */
     public static Tag parseTag(String tag) throws ParseException {
-        requireNonNull(tag);
+        if (tag.isBlank()) {
+            return null;
+        }
         String trimmedTag = tag.trim();
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
@@ -143,10 +147,11 @@ public class ParserUtil {
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
-        requireNonNull(tags);
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
-            tagSet.add(parseTag(tagName));
+            if (!tagName.isBlank()) {
+                tagSet.add(parseTag(tagName));
+            }
         }
         return tagSet;
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -98,7 +98,7 @@ public class ParserUtil {
      * @throws ParseException if the given {@code phone} is invalid.
      */
     public static Phone parsePhone(String phone) throws ParseException {
-        if (phone.isBlank()) {
+        if (phone == null || phone.isBlank()) {
             return new Phone(null);
         }
         String trimmedPhone = phone.trim();
@@ -116,7 +116,7 @@ public class ParserUtil {
      * @throws ParseException if the given {@code email} is invalid.
      */
     public static Email parseEmail(String email) throws ParseException {
-        if (email.isBlank()) {
+        if (email == null || email.isBlank()) {
             return new Email(null);
         }
         String trimmedEmail = email.trim();
@@ -133,7 +133,7 @@ public class ParserUtil {
      * @throws ParseException if the given {@code tag} is invalid.
      */
     public static Tag parseTag(String tag) throws ParseException {
-        if (tag.isBlank()) {
+        if (tag == null || tag.isBlank()) {
             return null;
         }
         String trimmedTag = tag.trim();
@@ -149,7 +149,7 @@ public class ParserUtil {
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
-            if (!tagName.isBlank()) {
+            if (tagName != null && !tagName.isBlank()) {
                 tagSet.add(parseTag(tagName));
             }
         }
@@ -226,7 +226,7 @@ public class ParserUtil {
      * @throws ParseException if the given {@code interviewDate} is invalid.
      */
     public static InterviewDate parseInterviewDate(String interviewDate) throws ParseException {
-        if (interviewDate.isBlank()) {
+        if (interviewDate == null || interviewDate.isBlank()) {
             return new InterviewDate(null);
         }
         String trimmedInterviewDate = interviewDate.trim();

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -227,7 +227,7 @@ public class ParserUtil {
      */
     public static InterviewDate parseInterviewDate(String interviewDate) throws ParseException {
         if (interviewDate.isBlank()) {
-            return null;
+            return new InterviewDate(null);
         }
         String trimmedInterviewDate = interviewDate.trim();
         if (!InterviewDate.isValidDatetimeStr(trimmedInterviewDate)) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -164,7 +164,7 @@ public class ParserUtil {
      * @throws ParseException if the given {@code internshipId} is invalid.
      */
     public static InternshipId parseInternshipId(String internshipId) throws ParseException {
-        if (internshipId == null) {
+        if (internshipId.isBlank()) {
             return null;
         }
         String trimmedInternshipId = internshipId.trim();
@@ -226,7 +226,9 @@ public class ParserUtil {
      * @throws ParseException if the given {@code interviewDate} is invalid.
      */
     public static InterviewDate parseInterviewDate(String interviewDate) throws ParseException {
-        requireNonNull(interviewDate);
+        if (interviewDate.isBlank()) {
+            return null;
+        }
         String trimmedInterviewDate = interviewDate.trim();
         if (!InterviewDate.isValidDatetimeStr(trimmedInterviewDate)) {
             throw new ParseException(InterviewDate.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/internship/Internship.java
+++ b/src/main/java/seedu/address/model/internship/Internship.java
@@ -62,6 +62,9 @@ public class Internship {
     }
 
     public InterviewDate getInterviewDate() {
+        if (interviewDate == null) {
+            return new InterviewDate(null);
+        }
         return interviewDate;
     }
 
@@ -112,11 +115,9 @@ public class Internship {
                 .append("; Role: ")
                 .append(getInternshipRole())
                 .append("; Status: ")
-                .append(getInternshipStatus());
-        if (getInterviewDate().toString() != null) {
-            builder.append("; InterviewDate: ")
-                    .append(getInterviewDate());
-        }
+                .append(getInternshipStatus())
+                .append("; InterviewDate: ")
+                .append(getInterviewDate());
 
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/internship/Internship.java
+++ b/src/main/java/seedu/address/model/internship/Internship.java
@@ -112,9 +112,11 @@ public class Internship {
                 .append("; Role: ")
                 .append(getInternshipRole())
                 .append("; Status: ")
-                .append(getInternshipStatus())
-                .append("; InterviewDate: ")
-                .append(getInterviewDate());
+                .append(getInternshipStatus());
+        if (getInterviewDate().toString() != null) {
+            builder.append("; InterviewDate: ")
+                    .append(getInterviewDate());
+        }
 
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/internship/InterviewDate.java
+++ b/src/main/java/seedu/address/model/internship/InterviewDate.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Objects;
 
 /**
  * Represents an Internship's interview date in the address book.
@@ -49,18 +50,7 @@ public class InterviewDate {
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
-            // short circuit if same object
-            return true;
-        } else if (other instanceof InterviewDate) {
-            // instanceof handles nulls
-            if (datetime == null || ((InterviewDate) other).datetime == null) {
-                // at least 1 of the values are null
-                return datetime == ((InterviewDate) other).datetime;
-            }
-            return datetime.equals(((InterviewDate) other).datetime); // state check
-        }
-        return false; // this is not null while other is null
+        return Objects.equals(datetime, ((InterviewDate) other).datetime);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/internship/InterviewDate.java
+++ b/src/main/java/seedu/address/model/internship/InterviewDate.java
@@ -1,6 +1,5 @@
 package seedu.address.model.internship;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.time.LocalDateTime;

--- a/src/main/java/seedu/address/model/internship/InterviewDate.java
+++ b/src/main/java/seedu/address/model/internship/InterviewDate.java
@@ -49,9 +49,18 @@ public class InterviewDate {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof InterviewDate // instanceof handles nulls
-                && datetime.equals(((InterviewDate) other).datetime)); // state check
+        if (other == this) {
+            // short circuit if same object
+            return true;
+        } else if (other instanceof InterviewDate) {
+            // instanceof handles nulls
+            if (datetime == null || ((InterviewDate) other).datetime == null) {
+                // at least 1 of the values are null
+                return datetime == ((InterviewDate) other).datetime;
+            }
+            return datetime.equals(((InterviewDate) other).datetime); // state check
+        }
+        return false; // this is not null while other is null
     }
 
     @Override

--- a/src/main/java/seedu/address/model/internship/InterviewDate.java
+++ b/src/main/java/seedu/address/model/internship/InterviewDate.java
@@ -26,11 +26,14 @@ public class InterviewDate {
      * @param datetimeStr A valid String in the format yyyy-MM-dd HH:mm that represents a date and time.
      */
     public InterviewDate(String datetimeStr) {
-        requireNonNull(datetimeStr);
-        checkArgument(isValidDatetimeStr(datetimeStr), MESSAGE_CONSTRAINTS);
+        if (datetimeStr == null || datetimeStr.isBlank()) {
+            this.datetime = null;
+        } else {
+            checkArgument(isValidDatetimeStr(datetimeStr), MESSAGE_CONSTRAINTS);
 
-        LocalDateTime datetime = LocalDateTime.parse(datetimeStr, formatter);
-        this.datetime = datetime;
+            LocalDateTime datetime = LocalDateTime.parse(datetimeStr, formatter);
+            this.datetime = datetime;
+        }
     }
 
     public static boolean isValidDatetimeStr(String test) {
@@ -39,6 +42,9 @@ public class InterviewDate {
 
     @Override
     public String toString() {
+        if (datetime == null) {
+            return null;
+        }
         return datetime.format(formatter);
     }
 

--- a/src/main/java/seedu/address/model/internship/InterviewDate.java
+++ b/src/main/java/seedu/address/model/internship/InterviewDate.java
@@ -42,7 +42,7 @@ public class InterviewDate {
     @Override
     public String toString() {
         if (datetime == null) {
-            return null;
+            return "No interviews scheduled";
         }
         return datetime.format(formatter);
     }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -2,6 +2,8 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Objects;
+
 /**
  * Represents a Person's email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
@@ -63,18 +65,7 @@ public class Email {
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
-            // short circuit if same object
-            return true;
-        } else if (other instanceof Email) {
-            // instanceof handles nulls
-            if (value == null || ((Email) other).value == null) {
-                // at least 1 of the values are null
-                return value == ((Email) other).value;
-            }
-            return value.equals(((Email) other).value); // state check
-        }
-        return false; // this is not null while other is null
+        return Objects.equals(value, ((Email) other).value);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -63,9 +63,18 @@ public class Email {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Email // instanceof handles nulls
-                && value.equals(((Email) other).value)); // state check
+        if (other == this) {
+            // short circuit if same object
+            return true;
+        } else if (other instanceof Email) {
+            // instanceof handles nulls
+            if (value == null || ((Email) other).value == null) {
+                // at least 1 of the values are null
+                return value == ((Email) other).value;
+            }
+            return value.equals(((Email) other).value); // state check
+        }
+        return false; // this is not null while other is null
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -55,6 +55,9 @@ public class Email {
 
     @Override
     public String toString() {
+        if (value == null) {
+            return "No email";
+        }
         return value;
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -121,11 +121,11 @@ public class Person {
         builder.append(getName());
         Email email = getEmail();
         if (email != null) {
-            builder.append(("; Email: "));
+            builder.append(("; Email: ")).append(getEmail());
         }
         Phone phone = getPhone();
         if (phone != null) {
-            builder.append(("; Phone: "));
+            builder.append(("; Phone: ")).append(getPhone());
         }
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -54,10 +54,16 @@ public class Person {
     }
 
     public Phone getPhone() {
+        if (phone == null) {
+            return new Phone(null);
+        }
         return phone;
     }
 
     public Email getEmail() {
+        if (email == null) {
+            return new Email(null);
+        }
         return email;
     }
 
@@ -118,15 +124,9 @@ public class Person {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append(getName());
-        Email email = getEmail();
-        if (email != null) {
-            builder.append(("; Email: ")).append(getEmail());
-        }
-        Phone phone = getPhone();
-        if (phone != null) {
-            builder.append(("; Phone: ")).append(getPhone());
-        }
+        builder.append(getName())
+                .append(("; Email: ")).append(getEmail())
+                .append(("; Phone: ")).append(getPhone());
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {
             builder.append("; Tags: ");

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -35,14 +35,22 @@ public class Phone {
 
     @Override
     public String toString() {
+        if (value == null) {
+            return "No phone number";
+        }
         return value;
     }
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Phone // instanceof handles nulls
-                && value.equals(((Phone) other).value)); // state check
+        if (other == this) {
+            // short circuit if same object
+            return true;
+        } else if (other instanceof Phone) {
+            // instanceof handles nulls
+            return value == ((Phone) other).value || value.equals(((Phone) other).value); // state check
+        }
+        return false; // this is not null while other is null
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -48,7 +48,11 @@ public class Phone {
             return true;
         } else if (other instanceof Phone) {
             // instanceof handles nulls
-            return value == ((Phone) other).value || value.equals(((Phone) other).value); // state check
+            if (value == null || ((Phone) other).value == null) {
+                // at least 1 of the values are null
+                return value == ((Phone) other).value;
+            }
+            return value.equals(((Phone) other).value); // state check
         }
         return false; // this is not null while other is null
     }

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -20,7 +20,6 @@ public class Phone {
      * @param phone A valid phone number.
      */
     public Phone(String phone) {
-        //requireNonNull(phone);
         if (phone != null) {
             checkArgument(isValidPhone(phone), MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -2,6 +2,8 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Objects;
+
 /**
  * Represents a Person's phone number in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidPhone(String)}
@@ -43,18 +45,7 @@ public class Phone {
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
-            // short circuit if same object
-            return true;
-        } else if (other instanceof Phone) {
-            // instanceof handles nulls
-            if (value == null || ((Phone) other).value == null) {
-                // at least 1 of the values are null
-                return value == ((Phone) other).value;
-            }
-            return value.equals(((Phone) other).value); // state check
-        }
-        return false; // this is not null while other is null
+        return Objects.equals(value, ((Phone) other).value);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/InternshipCard.java
+++ b/src/main/java/seedu/address/ui/InternshipCard.java
@@ -64,11 +64,7 @@ public class InternshipCard extends UiPart<Region> {
         } else {
             contactPerson.setText("Contact Person: " + contactPersonName);
         }
-        if (internship.getInterviewDate() == null) {
-            interviewDate.setText("No interviews scheduled.");
-        } else {
-            interviewDate.setText("Interview on: " + internship.getInterviewDate().toString());
-        }
+        interviewDate.setText("Interview on: " + internship.getInterviewDate().toString());
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -17,8 +17,8 @@ public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
     private static final String NO_INTERNSHIP = "No internship linked.";
-    private static final String NO_PHONE = null;
-    private static final String NO_EMAIL = null;
+    private static final String NO_PHONE = "No phone number.";
+    private static final String NO_EMAIL = "No email.";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -53,16 +53,8 @@ public class PersonCard extends UiPart<Region> {
         this.person = person;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
-        if (person.getPhone() == null) {
-            phone.setText(NO_PHONE);
-        } else {
-            phone.setText(person.getPhone().value);
-        }
-        if (person.getEmail() == null) {
-            email.setText(NO_EMAIL);
-        } else {
-            email.setText(person.getEmail().value);
-        }
+        phone.setText(person.getPhone().toString());
+        email.setText(person.getEmail().toString());
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -17,8 +17,6 @@ public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
     private static final String NO_INTERNSHIP = "No internship linked.";
-    private static final String NO_PHONE = "No phone number.";
-    private static final String NO_EMAIL = "No email.";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.

--- a/src/test/java/seedu/address/logic/parser/AddPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddPersonCommandParserTest.java
@@ -71,14 +71,13 @@ public class AddPersonCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
-        //Person expectedPersonTags = new PersonBuilder(AMY).withTags().build();
-        //assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY,
-        //        new AddPersonCommand(expectedPersonTags));
+        Person expectedPersonTags = new PersonBuilder(AMY).withTags().build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY,
+                new AddPersonCommand(expectedPersonTags));
         // zero phone
         Person expectedPersonPhone = new PersonBuilder(AMY).withPhone(null).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY,
                 new AddPersonCommand(expectedPersonPhone));
-        /*
         // zero email
         Person expectedPersonEmail = new PersonBuilder(AMY).withEmail(null).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY,
@@ -88,7 +87,6 @@ public class AddPersonCommandParserTest {
         Person expectedPersonEmailAndPhone = new PersonBuilder(AMY).withEmail(null).withPhone(null).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY,
                 new AddPersonCommand(expectedPersonEmailAndPhone));
-        */
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddPersonCommandParserTest.java
@@ -71,14 +71,14 @@ public class AddPersonCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
-        Person expectedPersonTags = new PersonBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY,
-                new AddPersonCommand(expectedPersonTags));
+        //Person expectedPersonTags = new PersonBuilder(AMY).withTags().build();
+        //assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY,
+        //        new AddPersonCommand(expectedPersonTags));
         // zero phone
         Person expectedPersonPhone = new PersonBuilder(AMY).withPhone(null).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY,
                 new AddPersonCommand(expectedPersonPhone));
-
+        /*
         // zero email
         Person expectedPersonEmail = new PersonBuilder(AMY).withEmail(null).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY,
@@ -88,6 +88,7 @@ public class AddPersonCommandParserTest {
         Person expectedPersonEmailAndPhone = new PersonBuilder(AMY).withEmail(null).withPhone(null).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY,
                 new AddPersonCommand(expectedPersonEmailAndPhone));
+        */
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditPersonCommandParserTest.java
@@ -90,12 +90,6 @@ public class EditPersonCommandParserTest {
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, "1" + PHONE_DESC_BOB + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS);
 
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
-        // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.testutil.Assert.assertDoesNotThrow;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -95,8 +96,8 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseEmail_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseEmail((String) null));
+    public void parseEmail_null_doesNotThrowException() {
+        assertDoesNotThrow(() -> ParserUtil.parseEmail(null));
     }
 
     @Test
@@ -118,8 +119,8 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseTag_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseTag(null));
+    public void parseTag_null_doesNotThrowException() {
+        assertDoesNotThrow(() -> ParserUtil.parseTag(null));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/Assert.java
+++ b/src/test/java/seedu/address/testutil/Assert.java
@@ -20,6 +20,17 @@ public class Assert {
     }
 
     /**
+     * Asserts that the {@code executable} does not throw any exceptions.
+     * This is a wrapper method that invokes {@link Assertions#assertDoesNotThrow(Executable)}, to maintain consistency
+     * with our custom {@link #assertThrows(Class, String, Executable)} method.
+     * To standardize API calls in this project, users should use this method instead of
+     * {@link Assertions#assertDoesNotThrow(Executable)}.
+     */
+    public static void assertDoesNotThrow(Executable executable) {
+        Assertions.assertDoesNotThrow(executable);
+    }
+
+    /**
      * Asserts that the {@code executable} throws the {@code expectedType} Exception with the {@code expectedMessage}.
      * If there's no need for the verification of the exception's error message, call
      * {@link #assertThrows(Class, Executable)} instead.

--- a/src/test/java/seedu/address/testutil/Assert.java
+++ b/src/test/java/seedu/address/testutil/Assert.java
@@ -20,17 +20,6 @@ public class Assert {
     }
 
     /**
-     * Asserts that the {@code executable} does not throw any exceptions.
-     * This is a wrapper method that invokes {@link Assertions#assertDoesNotThrow(Executable)}, to maintain consistency
-     * with our custom {@link #assertThrows(Class, String, Executable)} method.
-     * To standardize API calls in this project, users should use this method instead of
-     * {@link Assertions#assertDoesNotThrow(Executable)}.
-     */
-    public static void assertDoesNotThrow(Executable executable) {
-        Assertions.assertDoesNotThrow(executable);
-    }
-
-    /**
      * Asserts that the {@code executable} throws the {@code expectedType} Exception with the {@code expectedMessage}.
      * If there's no need for the verification of the exception's error message, call
      * {@link #assertThrows(Class, Executable)} instead.
@@ -42,4 +31,16 @@ public class Assert {
         Throwable thrownException = Assertions.assertThrows(expectedType, executable);
         Assertions.assertEquals(expectedMessage, thrownException.getMessage());
     }
+
+    /**
+     * Asserts that the {@code executable} does not throw any exceptions.
+     * This is a wrapper method that invokes {@link Assertions#assertDoesNotThrow(Executable)}, to maintain consistency
+     * with our custom {@link #assertThrows(Class, String, Executable)} method.
+     * To standardize API calls in this project, users should use this method instead of
+     * {@link Assertions#assertDoesNotThrow(Executable)}.
+     */
+    public static void assertDoesNotThrow(Executable executable) {
+        Assertions.assertDoesNotThrow(executable);
+    }
+
 }

--- a/src/test/java/seedu/address/testutil/InternshipBuilder.java
+++ b/src/test/java/seedu/address/testutil/InternshipBuilder.java
@@ -102,7 +102,11 @@ public class InternshipBuilder {
      * Sets the {@code Interview Date} of the {@code Internship} that we are building.
      */
     public InternshipBuilder withInterviewDate(String date) {
-        this.interviewDate = new InterviewDate(date);
+        if (date == null || date.isBlank()) {
+            this.interviewDate = new InterviewDate(null);
+        } else {
+            this.interviewDate = new InterviewDate(date);
+        }
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -19,8 +19,8 @@ public class PersonBuilder {
 
     public static final Integer DEFAULT_PERSON_ID = 0;
     public static final String DEFAULT_NAME = "Amy Bee";
-    public static final String DEFAULT_PHONE = "85355255";
-    public static final String DEFAULT_EMAIL = "amy@gmail.com";
+    public static final String DEFAULT_PHONE = "11111111";
+    public static final String DEFAULT_EMAIL = "amy@example.com";
 
     private PersonId personId;
     private Name name;
@@ -90,8 +90,8 @@ public class PersonBuilder {
      * Sets the {@code Phone} of the {@code Person} that we are building.
      */
     public PersonBuilder withPhone(String phone) {
-        if (phone == null) {
-            this.phone = null;
+        if (phone == null || phone.isBlank()) {
+            this.phone = new Phone(null);
         } else {
             this.phone = new Phone(phone);
         }
@@ -102,8 +102,8 @@ public class PersonBuilder {
      * Sets the {@code Email} of the {@code Person} that we are building.
      */
     public PersonBuilder withEmail(String email) {
-        if (email == null) {
-            this.email = null;
+        if (email == null || email.isBlank()) {
+            this.email = new Email(null);
         } else {
             this.email = new Email(email);
         }


### PR DESCRIPTION
Currently, including p/, e/, t/ or d/ would render the command invalid. The more suitable response is to ignore the field altogether and assign null, instead of rejecting the command.

For tags/interview date, instead of a null tag/interview date, it will return null directly (so no tag/interviewDate is created).

This change also fixes the result display of adding a person, where email and phone number is shown as blank.