### PR TITLE
Update InternshipCard in the GUI to display {company name}[space]{role}

### DIFF
--- a/src/main/java/seedu/address/model/internship/Internship.java
+++ b/src/main/java/seedu/address/model/internship/Internship.java
@@ -41,6 +41,10 @@ public class Internship {
         this.interviewDate = interviewDate;
     }
 
+    public String getDisplayName() {
+        return companyName.toString() + " " + internshipRole.toString();
+    }
+
     public InternshipId getInternshipId() {
         return internshipId;
     }

--- a/src/main/java/seedu/address/ui/InternshipCard.java
+++ b/src/main/java/seedu/address/ui/InternshipCard.java
@@ -29,6 +29,8 @@ public class InternshipCard extends UiPart<Region> {
     @FXML
     private HBox cardPane;
     @FXML
+    private Label name;
+    @FXML
     private Label companyName;
     @FXML
     private Label id;
@@ -48,6 +50,7 @@ public class InternshipCard extends UiPart<Region> {
         super(FXML);
         this.internship = internship;
         id.setText(displayedIndex + ". ");
+        name.setText(internship.getDisplayName());
         companyName.setText(internship.getCompanyName().fullName);
         role.setText(internship.getInternshipRole().roleName);
         status.getChildren().add(new Label(internship.getInternshipStatus().toString()));

--- a/src/main/resources/view/InternshipListCard.fxml
+++ b/src/main/resources/view/InternshipListCard.fxml
@@ -25,9 +25,10 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="companyName" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="status" />
+      <Label fx:id="companyName" styleClass="cell_small_label" text="\$companyName" />
       <Label fx:id="role" styleClass="cell_small_label" text="\$role" />
       <Label fx:id="contactPerson" styleClass="cell_small_label" text="\$contactPerson" />
       <Label fx:id="interviewDate" styleClass="cell_small_label" text="\$interviewDate" />


### PR DESCRIPTION
InternshipCard previous display the company name as the name of the internship, it has been changed to display
{company name}[space]{role} instead.

New method `getDisplayName()` has been added to Internship class.
All internships shown to users should have their name retrieved via `getDisplayName()`.