### PR TITLE
Add help messages to commands without flags

### DIFF
--- a/src/main/java/seedu/address/logic/commands/BaseCommandUtil.java
+++ b/src/main/java/seedu/address/logic/commands/BaseCommandUtil.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands;
+
+
+public class BaseCommandUtil {
+
+    /* Base Commands */
+    public static final String ADD_COMMAND = "add";
+    public static final String DELETE_COMMAND = "delete";
+    public static final String EDIT_COMMAND = "edit";
+    public static final String FIND_COMMAND = "find";
+    public static final String LIST_COMMAND = "list";
+    public static final String SORT_COMMAND = "sort";
+
+    /* Error Messages */
+    public static final String MESSAGE_BASE_COMMAND =
+            "Please use %1$s -p or %1$s -i to specify Person or Internship.";
+
+    // addressBookParser already checks if commandWord is valid and is the only class calling this method
+    public static String getErrorMessage(String commandWord) {
+        return String.format(MESSAGE_BASE_COMMAND, commandWord);
+    };
+}

--- a/src/main/java/seedu/address/logic/commands/BaseCommandUtil.java
+++ b/src/main/java/seedu/address/logic/commands/BaseCommandUtil.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.commands;
 
-
+/**
+ * Contains base command words for all commands that are shared among some commands and generate approperiate error
+ * messages
+ */
 public class BaseCommandUtil {
 
     /* Base Commands */

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddInternshipCommand;
 import seedu.address.logic.commands.AddPersonCommand;
+import seedu.address.logic.commands.BaseCommandUtil;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteInternshipCommand;
@@ -35,7 +36,7 @@ public class AddressBookParser {
      * Used for initial separation of command word and args.
      */
     private static final Pattern BASIC_COMMAND_FORMAT =
-            Pattern.compile("(?<commandWord>\\S+)(?<flag>\\s-\\S+)?(?<arguments>.*)");
+            Pattern.compile("(?<commandWord>^[^-\\s]+)(\\s+)?(?<flag>-\\S+)?(?<arguments>\\s.*)");
 
     /**
      * Parses user input into command for execution.
@@ -54,7 +55,7 @@ public class AddressBookParser {
         final String flag = matcher.group("flag");
         final String arguments = matcher.group("arguments");
         if (flag != null) {
-            commandWord = matcher.group("commandWord") + flag;
+            commandWord = matcher.group("commandWord") + " " + flag;
         } else {
             commandWord = matcher.group("commandWord");
         }
@@ -110,6 +111,24 @@ public class AddressBookParser {
 
         case SortInternshipCommand.COMMAND_WORD:
             return new SortInternshipCommandParser().parse(arguments);
+
+        case BaseCommandUtil.ADD_COMMAND:
+            throw new ParseException(BaseCommandUtil.getErrorMessage(BaseCommandUtil.ADD_COMMAND));
+
+        case BaseCommandUtil.DELETE_COMMAND:
+            throw new ParseException(BaseCommandUtil.getErrorMessage(BaseCommandUtil.DELETE_COMMAND));
+
+        case BaseCommandUtil.EDIT_COMMAND:
+            throw new ParseException(BaseCommandUtil.getErrorMessage(BaseCommandUtil.EDIT_COMMAND));
+
+        case BaseCommandUtil.FIND_COMMAND:
+            throw new ParseException(BaseCommandUtil.getErrorMessage(BaseCommandUtil.FIND_COMMAND));
+
+        case BaseCommandUtil.LIST_COMMAND:
+            throw new ParseException(BaseCommandUtil.getErrorMessage(BaseCommandUtil.LIST_COMMAND));
+
+        case BaseCommandUtil.SORT_COMMAND:
+            throw new ParseException(BaseCommandUtil.getErrorMessage(BaseCommandUtil.SORT_COMMAND));
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -36,7 +36,7 @@ public class AddressBookParser {
      * Used for initial separation of command word and args.
      */
     private static final Pattern BASIC_COMMAND_FORMAT =
-            Pattern.compile("(?<commandWord>^[^-\\s]+)(\\s+)?(?<flag>-\\S+)?(?<arguments>\\s.*)");
+            Pattern.compile("(?<commandWord>^[^-\\s]+)(\\s+)?(?<flag>-\\S+)?(?<arguments>\\s.*)?");
 
     /**
      * Parses user input into command for execution.
@@ -53,7 +53,7 @@ public class AddressBookParser {
 
         final String commandWord;
         final String flag = matcher.group("flag");
-        final String arguments = matcher.group("arguments");
+        final String arguments = matcher.group("arguments") == null ? "" : matcher.group("arguments");
         if (flag != null) {
             commandWord = matcher.group("commandWord") + " " + flag;
         } else {


### PR DESCRIPTION
Using add/delete/find/list/edit/sort without flags will now display a message to user to use flags.

Minor Update : 
- parser is now able to parser commands and flags with any number of whitespaces in between. `add-p` and `add -p` will now work