### PR TITLE
Fix sort criteria parsing

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortPersonCommand.java
@@ -16,9 +16,8 @@ public class SortPersonCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all persons based on person name "
             + "or company name. "
-            + "Parameters: [c/] [n/] (Only 1 criteria can be specified)\n"
+            + "Parameters: [c/] [n/] (Only 1 criterion can be specified)\n"
             + "Example: " + COMMAND_WORD + " c/";
-    public static final String MESSAGE_TOO_MANY_ARGUMENTS = "There should only be 1 sorting criterion.";
     public static final String MESSAGE_SUCCESS = "Sorted persons by %1$s";
 
     /**

--- a/src/main/java/seedu/address/logic/parser/SortPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortPersonCommandParser.java
@@ -23,14 +23,10 @@ public class SortPersonCommandParser implements Parser<SortPersonCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortPersonCommand.MESSAGE_USAGE));
         }
-        if (trimmedArgs.length() > 2) {
-            throw new ParseException(
-                    String.format(SortPersonCommand.MESSAGE_TOO_MANY_ARGUMENTS));
-        }
-        if (trimmedArgs.startsWith(PREFIX_NAME.getPrefix())) {
+        if (trimmedArgs.equalsIgnoreCase(PREFIX_NAME.getPrefix())) {
             return new SortPersonCommand(SortPersonCommand.Criteria.NAME);
         }
-        if (trimmedArgs.startsWith(PREFIX_COMPANY_NAME.getPrefix())) {
+        if (trimmedArgs.equalsIgnoreCase(PREFIX_COMPANY_NAME.getPrefix())) {
             return new SortPersonCommand(SortPersonCommand.Criteria.COMPANY_NAME);
         }
 


### PR DESCRIPTION
Previously, typing sort -p c/iehrivrhivn or sort -p n/ornvorv would cause the command to be accepted
Now it is changed to only accept sort -p c/ or sort -p n/