### PR TITLE
Fix UI and Command bugs, minor refactoring

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -116,7 +116,7 @@ Format: `add -p n/NAME [e/EMAIL] [p/PHONE_NUMBER] [t/TAG]…​ [l/LINK_INDEX] c
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 A person can have any number of tags (including 0). 
-Adding persons maintains the current sorted order of the display list (as opposed to adding to the back of the list). By default, the list is sorted by name.
+Adding persons maintains the current sorted order of the display list (as opposed to adding to the back of the list). By default, the list is sorted by date of creation.
 A person is assumed to be in charge of at most one internship position.
 A phone number is considered valid if it consists of at least 3 numbers (spaces, special characters, and letters are not allowed).
 Duplicate persons are not allowed.
@@ -141,7 +141,7 @@ Format: `add -i c/COMPANY_NAME r/ROLE s/STATUS [d/DATE_OF_INTERVIEW] [l/LINK_IND
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:** 
 Instead of typing the full status name, just enter the first letter of the intended status (e.g. `s/b` is a shortcut for `s/BOOKMARKED`)**.
-Adding internships maintains the current sorted order of the display list (as opposed to adding to the back of the list). By default, the list is sorted by company name.
+Adding internships maintains the current sorted order of the display list (as opposed to adding to the back of the list). By default, the list is sorted by date of creation.
 An internship is assumed to have at most one contact person.
 Duplicate internships are not allowed.
 An internship is considered to be duplicate if there already exists an internship in the list with the exact same company name and role (case-sensitive).

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -107,9 +107,8 @@ The UI component description:
 
 ### 4.1.1 Adding a person: `add -p`
 
-Adds a person to InterNUS. This person refers to the contact person you want to save. 
-During internship application this person could be the hiring manager. 
-After the application, this person could be the senior engineer who you want to keep contact at work.
+Saves a contact person into InterNUS, from the hiring manager you liase with 
+during the application process to the senior engineer you work with during the internship.
 
 Format: `add -p n/NAME [e/EMAIL] [p/PHONE_NUMBER] [t/TAG]…​ [l/LINK_INDEX] c/[COMPANY]`
 * The link index (in add -p) refers to the index number shown in the internship list.
@@ -117,10 +116,11 @@ Format: `add -p n/NAME [e/EMAIL] [p/PHONE_NUMBER] [t/TAG]…​ [l/LINK_INDEX] c
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 A person can have any number of tags (including 0). 
-New added person will be added in current sorted order.
-Only one contact person can be in-charge of one internship position.
-Phone number allows more than 2 digits without the need of any specific pattern.
-A person is only considered duplicated if the name is exactly the same including casing. 
+Adding persons maintains the current sorted order of the display list (as opposed to adding to the back of the list).
+A person is assumed to be in charge of at most one internship position.
+A phone number is considered valid if it consists of at least 3 numbers (spaces, special characters, and letters are not allowed).
+Duplicate persons are not allowed.
+A person is considered to be duplicate if there already exists a person in the list with the exact same name (case-sensitive).
 </div>
 
 Examples:
@@ -129,12 +129,13 @@ Examples:
 
 ### 4.1.2 Adding an internship: `add -i`
 
-Adds an Internship to InterNUS.
+Saves an internship into InterNUS. InterNUS will keep track of important details such as
+the internship's contact person, application status and interview date (if any).
 
 Format: `add -i c/COMPANY_NAME r/ROLE s/STATUS [d/DATE_OF_INTERVIEW] [l/LINK_INDEX]`
 
 * The link index (in add -i) refers to the index number shown in the person list.
-* Valid statuses are `BOOKMARKED`, `PENDING`, `ACCEPTED`, `COMPLETED` or `REJECTED` (case insensitive).
+* Valid statuses are `BOOKMARKED`, `PENDING`, `ACCEPTED`, `COMPLETED` or `REJECTED` (case-insensitive).
 * Date of interview is optional as interviews might not be scheduled yet.
 * `LINK_INDEX` refers to the index number shown in the person list and is optional. Specifying this parameter will define the current person at the specified index in the person list as the contact person of the newly added internship. 
 
@@ -185,7 +186,7 @@ Format: `edit -i INDEX [c/COMPANY] [r/ROLE] [s/STATUS] [d/INTERVIEW_DATE]`
 - Edits the internship at the specified `INDEX`. The index refers to the index number shown in the displayed internship list. The index must be a positive integer 1, 2, 3, …
 - At least one of the optional fields must be provided.
 - Existing values will be updated to the input values.
-- Valid statuses are `BOOKMARKED`, `PENDING`, `ACCEPTED`, `COMPLETED` or `REJECTED` (case insensitive). Similar to the `add  -i` command, the shortcuts can be used here.
+- Valid statuses are `BOOKMARKED`, `PENDING`, `ACCEPTED`, `COMPLETED` or `REJECTED` (case-insensitive). Similar to the `add  -i` command, the shortcuts can be used here.
 
 Examples:
 - `list -i` followed by `edit -i 1 s/ACCEPTED` Edits the status of the 1st internship to be `ACCEPTED`.
@@ -226,11 +227,12 @@ Examples:
 
 Finds persons whose fields contain any of the given keywords.
 
-Format: `find -p [n/ NAME_KEYWORD [MORE_KEYWORDS]...] [p/ PHONE_KEYWORD [MORE_KEYWORDS]...] [e/ EMAIL_KEYWORD [MORE_KEYWORDS]...] [t/ TAG_KEYWORD [MORE_KEYWORDS]...] [c/ COMPANY_KEYWORD [MORE_KEYWORDS]...]`
+Format: `find -p [n/ NAME_KEYWORDS...] [p/ PHONE_KEYWORDS...] [e/ EMAIL_KEYWORDS...] [t/ TAG_KEYWORDS...] [c/ COMPANY_KEYWORDS...]`
 - The search is case-insensitive. e.g **hans** will match **Hans**
 - The order of the keywords does not matter. e.g. **Hans Bo** will match **Bo Hans**
 - Only the fields corresponding to the specified prefixes will be searched,
   and all the specified fields must contain at least one of the specified keywords to be considered in the search result.
+- Absent fields will not be searched. e.g. **No company** will not find persons with blank company field.
 - Partial words will be matched. e.g. **Han** will match **Hans**
 
 Examples:
@@ -241,11 +243,12 @@ Examples:
 
 Finds internships whose fields contain any of the given keywords.
 
-Format: `find -i [c/ COMPANY_NAME_KEYWORD [MORE_KEYWORDS]...] [r/ INTERNSHIP_ROLE_KEYWORD [MORE_KEYWORDS]...] [s/ INTERNSHIP_STATUS_KEYWORD [MORE_KEYWORDS]...] [d/ INTERVIEW_DATE_KEYWORD [MORE_KEYWORDS]...]`
+Format: `find -i [c/ COMPANY_NAME_KEYWORDS...] [r/ INTERNSHIP_ROLE_KEYWORDS...] [s/ INTERNSHIP_STATUS_KEYWORDS...] [d/ INTERVIEW_DATE_KEYWORDS...]`
 - The search is case-insensitive. e.g **abc pte ltd** will match **ABC Pte Ltd**.
 - The order of the keywords does not matter. e.g. **Ltd ABC Pte Constructions** will match **ABC Constructions Pte Ltd**.
 - Only the fields corresponding to the specified prefixes will be searched,
   and all the specified fields must contain at least one of the specified keywords to be considered in the search result.
+- Absent fields will not be searched. e.g. **No interviews scheduled** will not find internships with blank interview date.
 - Partial words will be matched e.g. **app** will match **Apple** and **applications**.
 
 Example of usage:
@@ -263,7 +266,8 @@ Then,
 - `find -i c/g` returns **Google Inc** and **Garena**
 
 <div markdown="block" class="alert alert-info">
-**:information_source: Note:** The shortcuts for internship statuses don't work here.
+**:information_source: Note:** The shortcuts for internship statuses don't work here 
+since partial words will be matched. e.g. `e` will match with `ACCEPTED`,`REJECTED`, `PENDING`, `COMPLETED` and `BOOKMARKED` since they all contain the letter `e`.
 </div>
 
 ## 4.6 Delete Command

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -116,7 +116,7 @@ Format: `add -p n/NAME [e/EMAIL] [p/PHONE_NUMBER] [t/TAG]…​ [l/LINK_INDEX] c
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 A person can have any number of tags (including 0). 
-Adding persons maintains the current sorted order of the display list (as opposed to adding to the back of the list).
+Adding persons maintains the current sorted order of the display list (as opposed to adding to the back of the list). By default, the list is sorted by name.
 A person is assumed to be in charge of at most one internship position.
 A phone number is considered valid if it consists of at least 3 numbers (spaces, special characters, and letters are not allowed).
 Duplicate persons are not allowed.
@@ -139,7 +139,12 @@ Format: `add -i c/COMPANY_NAME r/ROLE s/STATUS [d/DATE_OF_INTERVIEW] [l/LINK_IND
 * Date of interview is optional as interviews might not be scheduled yet.
 * `LINK_INDEX` refers to the index number shown in the person list and is optional. Specifying this parameter will define the current person at the specified index in the person list as the contact person of the newly added internship. 
 
-<div markdown="span" class="alert alert-primary">:bulb: **Tip:** Instead of typing the full status name, just enter the first letter of the intended status (e.g. `s/b` is a shortcut for `s/BOOKMARKED`)**
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:** 
+Instead of typing the full status name, just enter the first letter of the intended status (e.g. `s/b` is a shortcut for `s/BOOKMARKED`)**.
+Adding internships maintains the current sorted order of the display list (as opposed to adding to the back of the list). By default, the list is sorted by company name.
+An internship is assumed to have at most one contact person.
+Duplicate internships are not allowed.
+An internship is considered to be duplicate if there already exists an internship in the list with the exact same company name and role (case-sensitive).
 </div>
 
 Examples:

--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -16,6 +16,7 @@ public class GuiSettings implements Serializable {
     private final double windowWidth;
     private final double windowHeight;
     private final Point windowCoordinates;
+    private final String colorTheme;
 
     /**
      * Constructs a {@code GuiSettings} with the default height, width and position.
@@ -24,6 +25,7 @@ public class GuiSettings implements Serializable {
         windowWidth = DEFAULT_WIDTH;
         windowHeight = DEFAULT_HEIGHT;
         windowCoordinates = null; // null represent no coordinates
+        colorTheme = null; // null represents no last used theme to load from
     }
 
     /**
@@ -33,6 +35,17 @@ public class GuiSettings implements Serializable {
         this.windowWidth = windowWidth;
         this.windowHeight = windowHeight;
         windowCoordinates = new Point(xPosition, yPosition);
+        colorTheme = null; // null represents no last used theme to load from
+    }
+
+    /**
+     * Constructs a {@code GuiSettings} with the specified height, width, position, and color theme.
+     */
+    public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition, String colorTheme) {
+        this.windowWidth = windowWidth;
+        this.windowHeight = windowHeight;
+        windowCoordinates = new Point(xPosition, yPosition);
+        this.colorTheme = colorTheme;
     }
 
     public double getWindowWidth() {
@@ -45,6 +58,10 @@ public class GuiSettings implements Serializable {
 
     public Point getWindowCoordinates() {
         return windowCoordinates != null ? new Point(windowCoordinates) : null;
+    }
+
+    public String getColorTheme() {
+        return colorTheme;
     }
 
     @Override
@@ -60,12 +77,13 @@ public class GuiSettings implements Serializable {
 
         return windowWidth == o.windowWidth
                 && windowHeight == o.windowHeight
-                && Objects.equals(windowCoordinates, o.windowCoordinates);
+                && Objects.equals(windowCoordinates, o.windowCoordinates)
+                && colorTheme == o.colorTheme;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(windowWidth, windowHeight, windowCoordinates);
+        return Objects.hash(windowWidth, windowHeight, windowCoordinates, colorTheme);
     }
 
     @Override
@@ -74,6 +92,7 @@ public class GuiSettings implements Serializable {
         sb.append("Width : " + windowWidth + "\n");
         sb.append("Height : " + windowHeight + "\n");
         sb.append("Position : " + windowCoordinates);
+        sb.append("Color Theme : " + colorTheme);
         return sb.toString();
     }
 }

--- a/src/main/java/seedu/address/commons/util/AppUtil.java
+++ b/src/main/java/seedu/address/commons/util/AppUtil.java
@@ -19,6 +19,14 @@ public class AppUtil {
     }
 
     /**
+     * Gets a string representation of the URL to the stylesheet from the specified theme.
+     */
+    public static String getStylesheetUrl(String theme) {
+        requireNonNull(theme);
+        return MainApp.class.getResource("/view/" + theme).toExternalForm();
+    }
+
+    /**
      * Checks that {@code condition} is true. Used for validating arguments to methods.
      *
      * @throws IllegalArgumentException if {@code condition} is false.

--- a/src/main/java/seedu/address/logic/commands/AddInternshipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInternshipCommand.java
@@ -28,7 +28,7 @@ import seedu.address.model.person.PersonId;
 public class AddInternshipCommand extends Command {
     public static final String COMMAND_WORD = "add -i";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a internship to InterNUS. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a internship to InterNUS.\n"
             + "Parameters: "
             + PREFIX_COMPANY_NAME + "COMPANY_NAME "
             + PREFIX_INTERNSHIP_ROLE + "INTERNSHIP_ROLE "
@@ -96,10 +96,11 @@ public class AddInternshipCommand extends Command {
         PersonId idToLink = contactPersonId;
 
         List<Person> lastShownList = model.getFilteredPersonList();
+        Person contactPerson = null;
         // If a linkIndex is supplied to the command,
         // attempt to find a contactPerson via the provided index in the filtered person list
         if (linkIndex != null && linkIndex.getZeroBased() < lastShownList.size()) {
-            Person contactPerson = lastShownList.get(linkIndex.getZeroBased());
+            contactPerson = lastShownList.get(linkIndex.getZeroBased());
 
             // The person to link to must not already be linked to an internship
             if (contactPerson.getInternshipId() == null) {
@@ -120,8 +121,21 @@ public class AddInternshipCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_INTERNSHIP);
         }
 
+        String linkMessage = "";
+        if (contactPerson != null) {
+            if (contactPerson.getInternshipId() == null) {
+                linkMessage = String.format("\nContact person linked successfully: "
+                        + LinkCommand.MESSAGE_SUCCESS, contactPerson.getName(), toAdd.getDisplayName());
+            } else {
+                linkMessage = String.format("\nWarning: Failed to link contact person: "
+                        + LinkCommand.MESSAGE_LINKED_PERSON,
+                        contactPerson.getName(),
+                        model.findInternshipById(contactPerson.getInternshipId()).getDisplayName());
+            }
+        }
+
         model.addInternship(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd) + linkMessage);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -34,7 +34,7 @@ public class AddPersonCommand extends Command {
 
     public static final String COMMAND_WORD = "add -p";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the InterNUS. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the InterNUS.\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + "[" + PREFIX_EMAIL + "EMAIL] "
@@ -103,13 +103,13 @@ public class AddPersonCommand extends Command {
         // By default, use the internshipId field in the command
         InternshipId idToLink = internshipId;
         List<Internship> lastShownList = model.getFilteredInternshipList();
+        Internship internshipToLink = null;
         if (linkIndex != null && linkIndex.getZeroBased() < lastShownList.size()) {
-            Internship internship = lastShownList.get(linkIndex.getZeroBased());
-            if (internship.getContactPersonId() == null) {
-                idToLink = internship.getInternshipId();
+            internshipToLink = lastShownList.get(linkIndex.getZeroBased());
+            if (internshipToLink.getContactPersonId() == null) {
+                idToLink = internshipToLink.getInternshipId();
             }
         }
-
 
         Person toAdd = new Person(
                 new PersonId(model.getNextPersonId()),
@@ -125,8 +125,21 @@ public class AddPersonCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        String linkMessage = "";
+        if (internshipToLink != null) {
+            if (internshipToLink.getContactPersonId() == null) {
+                linkMessage = String.format("\nInternship linked successfully: "
+                        + LinkCommand.MESSAGE_SUCCESS, name, internshipToLink.getDisplayName());
+            } else {
+                linkMessage = String.format("\nWarning: Failed to link internship: "
+                        + LinkCommand.MESSAGE_LINKED_INTERNSHIP,
+                        model.findPersonById(internshipToLink.getContactPersonId()).getName(),
+                        internshipToLink.getDisplayName());
+            }
+        }
+
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd) + linkMessage);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FindInternshipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindInternshipCommand.java
@@ -19,14 +19,15 @@ public class FindInternshipCommand extends Command {
     public static final String COMMAND_WORD = "find -i";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Finds all internships whose specified fields "
-            + "contains any of the specified keywords (case-insensitive) and displays them as a list with "
-            + "index numbers.\n"
+            + ": Finds all internships whose fields contain any of the specified keywords (case-insensitive) "
+            + "and displays them as a list with index numbers. "
+            + "Absent fields will not be searched. "
+            + "e.g. \"No interviews scheduled\" will not find internships with blank interview date.\n"
             + "Parameters: "
-            + "[" + PREFIX_COMPANY_NAME + " COMPANY_NAME_KEYWORD [MORE_KEYWORDS]...] "
-            + "[" + PREFIX_INTERNSHIP_ROLE + " INTERNSHIP_ROLE_KEYWORD [MORE_KEYWORDS]...] "
-            + "[" + PREFIX_INTERNSHIP_STATUS + " INTERNSHIP_STATUS_KEYWORD [MORE_KEYWORDS]...] "
-            + "[" + PREFIX_INTERVIEW_DATE + " INTERVIEW_DATE_KEYWORD [MORE_KEYWORDS]...]\n"
+            + "[" + PREFIX_COMPANY_NAME + " COMPANY_NAME_KEYWORDS...] "
+            + "[" + PREFIX_INTERNSHIP_ROLE + " INTERNSHIP_ROLE_KEYWORDS...] "
+            + "[" + PREFIX_INTERNSHIP_STATUS + " INTERNSHIP_STATUS_KEYWORDS...] "
+            + "[" + PREFIX_INTERVIEW_DATE + " INTERVIEW_DATE_KEYWORDS...]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_COMPANY_NAME + "abc pte ltd";
 
     private final InternshipContainsKeywordsPredicate predicate;

--- a/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
@@ -20,14 +20,16 @@ public class FindPersonCommand extends Command {
     public static final String COMMAND_WORD = "find -p";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Finds all persons whose fields contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + ": Finds all persons whose fields contain any of the specified keywords (case-insensitive) "
+            + "and displays them as a list with index numbers. "
+            + "Absent fields will not be searched. "
+            + "e.g. \"No company\" will not find persons with blank company field.\n"
             + "Parameters: "
-            + "[" + PREFIX_NAME + " NAME_KEYWORD [MORE_KEYWORDS]...] "
-            + "[" + PREFIX_PHONE + " PHONE_KEYWORD [MORE_KEYWORDS]...] "
-            + "[" + PREFIX_EMAIL + " EMAIL_KEYWORD [MORE_KEYWORDS]...] "
-            + "[" + PREFIX_TAG + " TAG_KEYWORD [MORE_KEYWORDS]...] "
-            + "[" + PREFIX_COMPANY + "COMPANY_KEYWORD [MORE_KEYWORDS]...]\n"
+            + "[" + PREFIX_NAME + " NAME_KEYWORDS...] "
+            + "[" + PREFIX_PHONE + " PHONE_KEYWORDS...] "
+            + "[" + PREFIX_EMAIL + " EMAIL_KEYWORDS...] "
+            + "[" + PREFIX_TAG + " TAG_KEYWORDS...] "
+            + "[" + PREFIX_COMPANY + "COMPANY_KEYWORDS...]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "alice bob charlie";
 
     private final PersonContainsKeywordsPredicate predicate;

--- a/src/main/java/seedu/address/logic/commands/LinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkCommand.java
@@ -22,7 +22,7 @@ public class LinkCommand extends Command {
 
     public static final String COMMAND_WORD = "link";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Links a Person and an Internship. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Links a Person and an Internship.\n"
             + "Parameters: "
             + PREFIX_PERSON + "PERSON_INDEX "
             + PREFIX_INTERNSHIP + "INTERNSHIP_ID\n"

--- a/src/main/java/seedu/address/logic/commands/SortInternshipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortInternshipCommand.java
@@ -12,10 +12,10 @@ public class SortInternshipCommand extends Command {
 
     public static final String COMMAND_WORD = "sort -i";
 
-    public static final String MESSAGE_USAGE =
-            COMMAND_WORD + ": Sorts internships by company, interview date, or internship status. "
-                    + "Parameters: [c/] [d/] [s/] (Only 1 criterion can be specified)\n"
-                    + "Example: " + COMMAND_WORD + " c/";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Sorts internships by company, interview date, or internship status.\n"
+            + "Parameters: [c/] [d/] [s/] (Only 1 criterion can be specified)\n"
+            + "Example: " + COMMAND_WORD + " c/";
 
     public static final String MESSAGE_SUCCESS = "Sorted internships by %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/SortPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortPersonCommand.java
@@ -14,8 +14,8 @@ public class SortPersonCommand extends Command {
 
     public static final String COMMAND_WORD = "sort -p";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all persons based on person name "
-            + "or company name. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Sorts all persons based on person name or company name.\n"
             + "Parameters: [c/] [n/] (Only 1 criterion can be specified)\n"
             + "Example: " + COMMAND_WORD + " c/";
 

--- a/src/main/java/seedu/address/logic/commands/UnlinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnlinkCommand.java
@@ -22,7 +22,7 @@ public class UnlinkCommand extends Command {
 
     public static final String COMMAND_WORD = "unlink";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Links a Person and an Internship. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Unlinks a Person and an Internship.\n"
             + "Parameters: "
             + PREFIX_PERSON + "PERSON_INDEX "
             + PREFIX_INTERNSHIP + "INTERNSHIP_ID\n"

--- a/src/main/java/seedu/address/logic/parser/AddInternshipCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddInternshipCommandParser.java
@@ -7,8 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LINK_INDEX;
 
-import java.util.stream.Stream;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddInternshipCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -38,7 +36,11 @@ public class AddInternshipCommandParser implements Parser<AddInternshipCommand> 
                         PREFIX_INTERVIEW_DATE,
                         PREFIX_LINK_INDEX);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_COMPANY_NAME, PREFIX_INTERNSHIP_ROLE, PREFIX_INTERNSHIP_STATUS)
+        if (!ParserUtil.arePrefixesPresent(
+                argMultimap,
+                PREFIX_COMPANY_NAME,
+                PREFIX_INTERNSHIP_ROLE,
+                PREFIX_INTERNSHIP_STATUS)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInternshipCommand.MESSAGE_USAGE));
         }
@@ -60,13 +62,4 @@ public class AddInternshipCommandParser implements Parser<AddInternshipCommand> 
 
         return new AddInternshipCommand(companyName, internshipRole, internshipStatus, interviewDate, linkIndex);
     }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddPersonCommand;
@@ -42,7 +41,7 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
                         PREFIX_LINK_INDEX,
                         PREFIX_COMPANY);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
+        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPersonCommand.MESSAGE_USAGE));
         }
@@ -62,13 +61,4 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
 
         return new AddPersonCommand(name, email, phone, tagList, linkIndex, company);
     }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/FindInternshipCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindInternshipCommandParser.java
@@ -32,7 +32,13 @@ public class FindInternshipCommandParser implements Parser<FindInternshipCommand
                         PREFIX_INTERNSHIP_STATUS,
                         PREFIX_INTERVIEW_DATE);
 
-        if (!argMultimap.getPreamble().isEmpty()) {
+        if (!ParserUtil.isAnyPrefixPresent(
+                argMultimap,
+                PREFIX_COMPANY_NAME,
+                PREFIX_INTERNSHIP_ROLE,
+                PREFIX_INTERNSHIP_STATUS,
+                PREFIX_INTERVIEW_DATE)
+                || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindInternshipCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/FindPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindPersonCommandParser.java
@@ -34,7 +34,14 @@ public class FindPersonCommandParser implements Parser<FindPersonCommand> {
                         PREFIX_TAG,
                         PREFIX_COMPANY);
 
-        if (!argMultimap.getPreamble().isEmpty()) {
+        if (!ParserUtil.isAnyPrefixPresent(
+                argMultimap,
+                PREFIX_NAME,
+                PREFIX_EMAIL,
+                PREFIX_PHONE,
+                PREFIX_TAG,
+                PREFIX_COMPANY)
+                || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindPersonCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -251,5 +252,20 @@ public class ParserUtil {
             throw new ParseException(InterviewDate.MESSAGE_CONSTRAINTS);
         }
         return new InterviewDate(trimmedInterviewDate);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Returns true if any of the prefixes are present {@code ArgumentMultimap}.
+     */
+    public static boolean isAnyPrefixPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -143,6 +143,9 @@ public class ModelManager implements Model {
 
     @Override
     public void refreshPersonList() {
+        // Since we are just swapping between 2 observable lists and they are wrappers around
+        // the source list, it is safe to swap between SortedList and FilteredList.
+        @SuppressWarnings("unchecked")
         FilteredList<Person> personList = (FilteredList<Person>) filteredPersons.getSource();
         Predicate<? super Person> predicate = personList.getPredicate();
         personList.setPredicate(PREDICATE_SHOW_NO_PERSONS);
@@ -190,6 +193,9 @@ public class ModelManager implements Model {
 
     @Override
     public void refreshInternshipList() {
+        // Since we are just swapping between 2 observable lists and they are wrappers around
+        // the source list, it is safe to swap between SortedList and FilteredList.
+        @SuppressWarnings("unchecked")
         FilteredList<Internship> internshipList = (FilteredList<Internship>) filteredInternships.getSource();
         Predicate<? super Internship> predicate = internshipList.getPredicate();
         internshipList.setPredicate(PREDICATE_SHOW_NO_INTERNSHIPS);

--- a/src/main/java/seedu/address/model/internship/Internship.java
+++ b/src/main/java/seedu/address/model/internship/Internship.java
@@ -132,8 +132,6 @@ public class Internship {
         }
 
         Internship otherInternship = (Internship) other;
-        // solution adapted from
-        // https://stackoverflow.com/a/36716166
         return otherInternship.getInternshipId().equals(getInternshipId())
                 && otherInternship.getCompanyName().equals(getCompanyName())
                 && otherInternship.getInternshipRole().equals(getInternshipRole())
@@ -157,7 +155,7 @@ public class Internship {
                 .append(getInternshipRole())
                 .append("; Status: ")
                 .append(getInternshipStatus())
-                .append("; InterviewDate: ")
+                .append("; Interview Date: ")
                 .append(getInterviewDate());
 
         return builder.toString();

--- a/src/main/java/seedu/address/model/internship/InternshipStatus.java
+++ b/src/main/java/seedu/address/model/internship/InternshipStatus.java
@@ -6,8 +6,10 @@ package seedu.address.model.internship;
  */
 public class InternshipStatus {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Status can only be BOOKMARKED, PENDING, ACCEPTED, COMPLETED or REJECTED and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Status can only be "
+            + "BOOKMARKED, PENDING, ACCEPTED, COMPLETED or REJECTED "
+            + "(short-forms corresponding to first letter: B, P, A, C, R), and are case-insensitive. "
+            + "Status should not be blank.";
 
     /**
      * Represents the possible states of an InternshipStatus.

--- a/src/main/java/seedu/address/model/internship/InterviewDate.java
+++ b/src/main/java/seedu/address/model/internship/InterviewDate.java
@@ -4,6 +4,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.Objects;
 
 /**
@@ -11,12 +13,12 @@ import java.util.Objects;
  * Guarantees: immutable; is valid as declared in {@link #isValidDatetimeStr(String)} (String)}
  */
 public class InterviewDate {
-    public static final String MESSAGE_CONSTRAINTS =
-            "Interview dates must be in the format yyyy-MM-dd HH:mm, and it should not blank";
+    public static final String MESSAGE_CONSTRAINTS = "Interview date must be "
+            + "a valid date (present in a calendar) with valid time (24-hour format), "
+            + "and given in the exact format yyyy-MM-dd HH:mm.";
 
-    public static final String VALIDATION_REGEX = "\\d{4}-[01]\\d-[0-3]\\d\\s[0-2]\\d((:[0-5]\\d)?){2}";
-
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private static final DateTimeFormatter formatter =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm").withResolverStyle(ResolverStyle.STRICT);
 
     public final LocalDateTime datetime;
 
@@ -36,8 +38,16 @@ public class InterviewDate {
         }
     }
 
+    /**
+     * Returns true if the given String can be parsed to a valid {@Code LocalDateTime}.
+     */
     public static boolean isValidDatetimeStr(String test) {
-        return test.matches(VALIDATION_REGEX);
+        try {
+            LocalDateTime.parse(test, formatter);
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
     }
 
     @Override
@@ -48,8 +58,6 @@ public class InterviewDate {
         return datetime.format(formatter);
     }
 
-    // solution adapted from
-    // https://stackoverflow.com/a/36716166
     @Override
     public boolean equals(Object other) {
         return Objects.equals(datetime, ((InterviewDate) other).datetime);

--- a/src/main/java/seedu/address/model/person/Company.java
+++ b/src/main/java/seedu/address/model/person/Company.java
@@ -42,7 +42,7 @@ public class Company implements Comparable<Company> {
     @Override
     public String toString() {
         if (fullName == null) {
-            return "No Company";
+            return "No company";
         }
         return fullName;
     }

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 
-import seedu.address.model.tag.Tag;
-
 /**
  * Tests that a {@code Person}'s {@code Name}, {@code Phone},
  * {@code Email}, and {@code Tags} match any of the keywords given.
@@ -46,7 +44,8 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
                     keyword -> person.getEmail().value != null
                             && person.getEmail().value.toLowerCase().contains(keyword.toLowerCase())))
                 && (tagKeywords.isEmpty() || tagKeywords.stream().anyMatch(
-                        keyword -> person.getTags() != null && person.getTags().contains(new Tag(keyword))))
+                    keyword -> person.getTags() != null
+                            && person.getTags().stream().anyMatch(t -> t.tagName.toLowerCase().contains(keyword))))
                 && (companyKeywords.isEmpty() || companyKeywords.stream().anyMatch(
                     keyword -> person.getCompany().fullName != null
                             && person.getCompany().fullName.toLowerCase().contains(keyword.toLowerCase())));
@@ -64,8 +63,6 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
 
         PersonContainsKeywordsPredicate otherPredicate = (PersonContainsKeywordsPredicate) other;
 
-        // solution adapted from
-        // https://stackoverflow.com/a/36716166
         return Objects.equals(nameKeywords, otherPredicate.nameKeywords)
                 && Objects.equals(phoneKeywords, otherPredicate.phoneKeywords)
                 && Objects.equals(emailKeywords, otherPredicate.emailKeywords)

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -26,6 +26,7 @@ import seedu.address.logic.commands.ListInternshipCommand;
 import seedu.address.logic.commands.ListPersonCommand;
 import seedu.address.logic.commands.SortInternshipCommand;
 import seedu.address.logic.commands.SortPersonCommand;
+import seedu.address.logic.commands.UnlinkCommand;
 
 /**
  * Controller for a help page
@@ -39,22 +40,23 @@ public class HelpWindow extends UiPart<Stage> {
     private static final String FXML = "HelpWindow.fxml";
 
     private static final String COMMAND_SUMMARY = "SUMMARY OF COMMANDS:\n\n"
-            + HelpCommand.COMMAND_WORD + ": Opens this help window\n\n"
+            + HelpCommand.COMMAND_WORD + ": Opens this help window.\n\n"
             + AddPersonCommand.MESSAGE_USAGE + "\n\n"
             + AddInternshipCommand.MESSAGE_USAGE + "\n\n"
-            + ListPersonCommand.COMMAND_WORD + ": Lists all persons\n\n"
-            + ListInternshipCommand.COMMAND_WORD + ": Lists all internships\n\n"
+            + ListPersonCommand.COMMAND_WORD + ": Lists all persons.\n\n"
+            + ListInternshipCommand.COMMAND_WORD + ": Lists all internships.\n\n"
             + EditPersonCommand.MESSAGE_USAGE + "\n\n"
             + EditInternshipCommand.MESSAGE_USAGE + "\n\n"
             + LinkCommand.MESSAGE_USAGE + "\n\n"
+            + UnlinkCommand.MESSAGE_USAGE + "\n\n"
             + FindPersonCommand.MESSAGE_USAGE + "\n\n"
             + FindInternshipCommand.MESSAGE_USAGE + "\n\n"
             + DeletePersonCommand.MESSAGE_USAGE + "\n\n"
             + DeleteInternshipCommand.MESSAGE_USAGE + "\n\n"
             + SortPersonCommand.MESSAGE_USAGE + "\n\n"
             + SortInternshipCommand.MESSAGE_USAGE + "\n\n"
-            + ClearCommand.COMMAND_WORD + ": Clears all entries\n\n"
-            + ExitCommand.COMMAND_WORD + ": Exits the program";
+            + ClearCommand.COMMAND_WORD + ": Clears all entries.\n\n"
+            + ExitCommand.COMMAND_WORD + ": Exits the program.";
 
     @FXML
     private Button copyButton;
@@ -63,7 +65,7 @@ public class HelpWindow extends UiPart<Stage> {
     private Label helpMessage;
 
     @FXML
-    private TextArea commandSummaryDisplay;
+    private TextArea resultDisplay;
 
     /**
      * Creates a new HelpWindow.
@@ -74,7 +76,7 @@ public class HelpWindow extends UiPart<Stage> {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
 
-        commandSummaryDisplay.setText(COMMAND_SUMMARY);
+        resultDisplay.setText(COMMAND_SUMMARY);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/InternshipCard.java
+++ b/src/main/java/seedu/address/ui/InternshipCard.java
@@ -13,7 +13,7 @@ import seedu.address.model.person.PersonId;
  */
 public class InternshipCard extends UiPart<Region> {
 
-    static final String NO_CONTACT_PERSON = "No contact person.";
+    static final String NO_CONTACT_PERSON = "No contact person";
     private static final String FXML = "InternshipListCard.fxml";
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -2,7 +2,6 @@ package seedu.address.ui;
 
 import static javafx.application.Application.setUserAgentStylesheet;
 
-import java.net.URL;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
@@ -16,6 +15,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.util.AppUtil;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -26,8 +26,12 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * a menu bar and space where other JavaFX elements can be placed.
  */
 public class MainWindow extends UiPart<Stage> {
-
+    public static final String LIGHT_THEME = "LightTheme.css";
+    public static final String DARK_THEME = "DarkTheme.css";
+    public static final String EXTENSIONS = "Extensions.css";
     private static final String FXML = "MainWindow.fxml";
+
+    private static String currentTheme = "LightTheme.css";
 
     private final Logger logger = LogsCenter.getLogger(getClass());
 
@@ -58,18 +62,6 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private StackPane statusbarPlaceholder;
 
-    @FXML
-    private URL lightTheme;
-
-    @FXML
-    private URL darkTheme;
-
-    @FXML
-    private URL extensions;
-
-    @FXML
-    private Scene mainScene;
-
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
      */
@@ -81,7 +73,7 @@ public class MainWindow extends UiPart<Stage> {
         this.logic = logic;
 
         // Configure the UI
-        setWindowDefaultSize(logic.getGuiSettings());
+        loadGuiSettings(logic.getGuiSettings());
 
         setAccelerators();
 
@@ -161,13 +153,15 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Sets the default size based on {@code guiSettings}.
      */
-    private void setWindowDefaultSize(GuiSettings guiSettings) {
+    private void loadGuiSettings(GuiSettings guiSettings) {
         primaryStage.setHeight(guiSettings.getWindowHeight());
         primaryStage.setWidth(guiSettings.getWindowWidth());
         if (guiSettings.getWindowCoordinates() != null) {
             primaryStage.setX(guiSettings.getWindowCoordinates().getX());
             primaryStage.setY(guiSettings.getWindowCoordinates().getY());
         }
+
+        setWindowThemes(guiSettings.getColorTheme());
     }
 
     /**
@@ -177,6 +171,7 @@ public class MainWindow extends UiPart<Stage> {
     public void handleHelp() {
         if (!helpWindow.isShowing()) {
             helpWindow.show();
+            updateTheme(helpWindow.getRoot().getScene());
         } else {
             helpWindow.focus();
         }
@@ -192,7 +187,7 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void handleExit() {
         GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
-                (int) primaryStage.getX(), (int) primaryStage.getY());
+                (int) primaryStage.getX(), (int) primaryStage.getY(), currentTheme);
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
         primaryStage.hide();
@@ -200,20 +195,37 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private void handleLightThemeSwitch() {
-        mainScene.getStylesheets().clear();
-        setUserAgentStylesheet(null);
-
-        mainScene.getStylesheets().add("file:" + lightTheme.getPath());
-        mainScene.getStylesheets().add("file:" + extensions.getPath());
+        setWindowThemes(LIGHT_THEME);
     }
 
     @FXML
     private void handleDarkThemeSwitch() {
-        mainScene.getStylesheets().clear();
+        setWindowThemes(DARK_THEME);
+    }
+
+    private void setWindowThemes(String theme) {
+        setTheme(theme);
+        updateTheme(getRoot().getScene());
+
+        if (helpWindow != null && helpWindow.isShowing()) {
+            updateTheme(helpWindow.getRoot().getScene());
+        }
+    }
+
+    private void setTheme(String theme) {
+        if (theme == null || theme.isBlank()) {
+            return;
+        }
+
+        currentTheme = theme;
+    }
+
+    private void updateTheme(Scene scene) {
+        scene.getStylesheets().clear();
         setUserAgentStylesheet(null);
 
-        mainScene.getStylesheets().add("file:" + darkTheme.getPath());
-        mainScene.getStylesheets().add("file:" + extensions.getPath());
+        scene.getStylesheets().add(AppUtil.getStylesheetUrl(currentTheme));
+        scene.getStylesheets().add(AppUtil.getStylesheetUrl(EXTENSIONS));
     }
 
     public PersonListPanel getPersonListPanel() {

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -16,7 +16,7 @@ import seedu.address.model.person.Person;
 public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
-    private static final String NO_INTERNSHIP = "No internship linked.";
+    private static final String NO_INTERNSHIP = "No internship linked";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -58,11 +58,7 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
-        if (person.getInternshipId() == null) {
-            internship.setText(NO_INTERNSHIP);
-        } else {
-            internship.setText("Internship: " + person.getInternshipId().toString());
-        }
+        internship.setText(NO_INTERNSHIP); // dummy value
         company.setText(person.getCompany().toString());
     }
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -123,6 +123,7 @@
 
 .list-cell .label {
     -fx-text-fill: white;
+    -fx-wrap-text: "true";
 }
 
 .cell_big_label {
@@ -345,6 +346,7 @@
 #tags {
     -fx-hgap: 7;
     -fx-vgap: 3;
+    -fx-min-width: 110px;
 }
 
 #tags .label {
@@ -354,6 +356,8 @@
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
+    -fx-max-width: 100px;
+    -fx-wrap-text: "true";
 }
 
 #status .label {
@@ -363,4 +367,24 @@
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
+}
+
+#helpContainer, #helpMessageContainer {
+    -fx-background-color: derive(-fx-dark-background-primary, 20%);
+}
+
+#copyButton, #helpMessage {
+    -fx-text-fill: white;
+}
+
+#copyButton {
+    -fx-background-color: dimgray;
+}
+
+#copyButton:hover {
+    -fx-background-color: gray;
+}
+
+#copyButton:armed {
+    -fx-background-color: darkgray;
 }

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -19,7 +19,9 @@
   <scene>
     <Scene>
       <stylesheets>
-        <URL value="@HelpWindow.css" />
+        <URL fx:id="lightTheme" value="@LightTheme.css" />
+        <URL fx:id="darkTheme" value="@DarkTheme.css" />
+        <URL fx:id="extensions" value="@Extensions.css" />
       </stylesheets>
 
       <VBox alignment="CENTER" fx:id="helpContainer">
@@ -44,7 +46,7 @@
         </padding>
       </HBox>
       <StackPane xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1">
-        <TextArea fx:id="commandSummaryDisplay" editable="false" wrapText="true" />
+        <TextArea fx:id="resultDisplay" styleClass="result-display" editable="false" wrapText="true" />
       </StackPane>
       </VBox>
     </Scene>

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -123,6 +123,7 @@
 
 .list-cell .label {
     -fx-text-fill: black;
+    -fx-wrap-text: "true";
 }
 
 .cell_big_label {
@@ -159,7 +160,7 @@
 }
 
 .result-display .label {
-    -fx-text-fill: black !important;
+    -fx-text-fill: white !important;
 }
 
 .status-bar .label {
@@ -345,6 +346,7 @@
 #tags {
     -fx-hgap: 7;
     -fx-vgap: 3;
+    -fx-min-width: 110px;
 }
 
 #tags .label {
@@ -354,6 +356,8 @@
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
+    -fx-max-width: 100px;
+    -fx-wrap-text: "true";
 }
 
 #status .label {
@@ -363,4 +367,24 @@
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
+}
+
+#helpContainer, #helpMessageContainer {
+    -fx-background-color: derive(-fx-light-background-primary, 20%);
+}
+
+#copyButton, #helpMessage {
+    -fx-text-fill: black;
+}
+
+#copyButton {
+    -fx-background-color: darkgray;
+}
+
+#copyButton:hover {
+    -fx-background-color: gray;
+}
+
+#copyButton:armed {
+    -fx-background-color: dimgray;
 }

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true" />
 </StackPane>


### PR DESCRIPTION
### Changes
- Fix text truncation causing long strings of text to be hidden 
    - Enable text wrapping for all fields of person and internship cards
    - Adjust min and max width of some elements to ensure correct wrapping
- Fix color theme bugs 
    - Color themes should now work on build version correctly in a fresh directory. The issue was a relative file path issue causing the `.css` files to not be found. 
    - Color themes should now be loaded in and saved correctly
- Fix missing commands in help window
- Fix `ResultDisplay.fxml` causing warnings to be displayed due to improper javafx version
- Fix add command bugs 
    - Interview date was not being parsed correctly, allowing some invalid inputs to be accepted 
    - Command message was not informing user when linking in the add command failed (but the add command still went through), so a warning is now displayed
- Fix find commands not throwing exception when no arguments were supplied
- Fix tag searching for find person command 
    - Previously, keywords had to match tags exactly, which was inconsistent with how every other field was searched. Now partial matches are allowed
- Update command and error messages to be clearer and consistent in general with UG
- Abstract some common code used in command parsers into `ParserUtil`
- Address warnings in `ModelManager` with regards to explicit casting

### Resolves
- #262 
- #243 
- #236 
- #234 
- #229 
- #226 
- #220 
- #218 
- #217 
- #211 
- #207 
- #202 
- #201 
- #199 
- #195 
- #176 